### PR TITLE
Add leaderboards for Infinite Parkour

### DIFF
--- a/leaderboards/infiniteparkour/all_time_points.json
+++ b/leaderboards/infiniteparkour/all_time_points.json
@@ -1,0 +1,11 @@
+{
+    "id": "infiniteparkour:all_time_points",
+    "query": {
+        "statistic": {
+            "namespace": "infinite_parkour",
+            "key": "plasmid:points",
+            "aggregate": "total",
+            "ranking": "highest"
+        }
+    }
+}

--- a/leaderboards/infiniteparkour/points.json
+++ b/leaderboards/infiniteparkour/points.json
@@ -1,0 +1,11 @@
+{
+    "id": "infiniteparkour:points",
+    "query": {
+        "statistic": {
+            "namespace": "infinite_parkour",
+            "key": "plasmid:points",
+            "aggregate": "maximum",
+            "ranking": "highest"
+        }
+    }
+}

--- a/translations/en_us.json
+++ b/translations/en_us.json
@@ -22,6 +22,8 @@
     "leaderboard.fortress.modules_placed": "Modules placed",
     "leaderboard.fortress.rows_captured": "Rows captured",
     "leaderboard.fortress.total_kills": "Kills",
+    "leaderboard.infiniteparkour.all_time_points": "All-time points",
+    "leaderboard.infiniteparkour.points": "Points",
     "leaderboard.intermediate_withersweeper.fields_uncovered": "Fields uncovered",
     "leaderboard.intermediate_withersweeper.games_won": "Games won",
     "leaderboard.intermediate_withersweeper.quickest_time": "Quickest time",


### PR DESCRIPTION
This pull request adds the following leaderboards for the Infinite Parkour game:

- All-time points
- Points